### PR TITLE
fix: VideoQuality.value=None 导致视频下载崩溃

### DIFF
--- a/core/bilibili/handler.py
+++ b/core/bilibili/handler.py
@@ -158,6 +158,10 @@ class BilibiliMixin:
         if not candidates:
             fallback = "_720P"
             return fallback, getattr(VideoQuality, fallback)
+        candidates = [q for q in candidates if q.value is not None]
+        if not candidates:
+            fallback = "_720P"
+            return fallback, getattr(VideoQuality, fallback)
         best = max(candidates, key=lambda item: item.value)
         return best.name, best
 
@@ -173,6 +177,10 @@ class BilibiliMixin:
         if not candidates:
             fallback = "_720P"
             return fallback, getattr(VideoQuality, fallback)
+        candidates = [q for q in candidates if q.value is not None]
+        if not candidates:
+            fallback = "_720P"
+            return fallback, getattr(VideoQuality, fallback)
         lowest = min(candidates, key=lambda item: item.value)
         return lowest.name, lowest
 
@@ -184,7 +192,7 @@ class BilibiliMixin:
                 continue
             if not self.allow_dolby and "DOLBY" in name:
                 continue
-            if quality.value < current_quality.value:
+            if quality.value is not None and quality.value < current_quality.value:
                 candidates.append(quality)
         return sorted(candidates, key=lambda q: q.value, reverse=True)
 


### PR DESCRIPTION
## 问题

```
[bilibili.handler:1193]: ❌ 视频下载失败: 'NoneType' object has no attribute 'value'
```

## 根因

`bilibili_api` 的 `VideoQuality` 枚举中某些成员 `.value` 为 `None`（可能是 API 版本变化导致），在以下三处 `max()`/`min()`/`sorted()` 排序时崩溃：

- `_max_allowed_quality()` — `max(candidates, key=lambda item: item.value)`
- `_min_allowed_quality()` — `min(candidates, key=lambda item: item.value)`  
- `_get_lower_qualities()` — `sorted(candidates, key=lambda q: q.value)`

## 修复

在每次排序前过滤掉 `.value is None` 的成员，并增加二次判空兜底。

## 测试

- [x] B站视频解析不再因画质枚举崩溃
- [x] 正常画质选择逻辑不受影响